### PR TITLE
feat: 视频流接口及相关响应体构造

### DIFF
--- a/controller/feed.go
+++ b/controller/feed.go
@@ -1,7 +1,10 @@
 package controller
 
 import (
+	"github.com/YouthCampProj/douyin/service"
+	"github.com/YouthCampProj/douyin/utils"
 	"github.com/gin-gonic/gin"
+	"time"
 )
 
 // InitFeedRoute 初始化视频流相关路由
@@ -17,6 +20,14 @@ func InitFeedRoute(r *gin.RouterGroup) {
 // https://www.apifox.cn/apidoc/shared-8cc50618-0da6-4d5e-a398-76f3b8f766c5/api-18345145
 func GetFeed(c *gin.Context) {
 	//可选参数，限制返回视频的最新投稿时间戳，精确到秒，不填表示当前时间
-	//latestTime := c.DefaultQuery("latest_time", time.Now().String())
+	latestTime := utils.Str2int64(c.Query("latest_time"))
+	if latestTime == 0 {
+		latestTime = time.Now().Unix()
+	}
+
 	//TODO: 视频流接口
+	feedService := &service.FeedService{
+		LatestTime: latestTime,
+	}
+	feedService.GetFeed()
 }

--- a/controller/feed.go
+++ b/controller/feed.go
@@ -25,9 +25,8 @@ func GetFeed(c *gin.Context) {
 		latestTime = time.Now().Unix()
 	}
 
-	//TODO: 视频流接口
 	feedService := &service.FeedService{
 		LatestTime: latestTime,
 	}
-	feedService.GetFeed()
+	c.JSON(200, feedService.GetFeed())
 }

--- a/controller/publish.go
+++ b/controller/publish.go
@@ -14,7 +14,6 @@ func InitPublishRoute(r *gin.RouterGroup) {
 // POST /douyin/publish/action/
 // https://www.apifox.cn/apidoc/shared-8cc50618-0da6-4d5e-a398-76f3b8f766c5/api-18875092
 func PublishAction(c *gin.Context) {
-	//userid := c.Query("user_id")
 	//token := c.Query("token")
 	//data, err := c.FormFile("data")
 	// TODO 投稿接口
@@ -26,7 +25,6 @@ func PublishAction(c *gin.Context) {
 // GET /douyin/publish/list/
 // https://www.apifox.cn/apidoc/shared-8cc50618-0da6-4d5e-a398-76f3b8f766c5/api-18901444
 func GetPublishList(c *gin.Context) {
-	//userid := c.Query("user_id")
 	//token := c.Query("token")
 	// TODO 发布列表接口
 }

--- a/model/video.go
+++ b/model/video.go
@@ -1,5 +1,7 @@
 package model
 
+import "time"
+
 // Video 视频信息
 type Video struct {
 	Common
@@ -8,4 +10,14 @@ type Video struct {
 	CoverURL      string `json:"cover_url"` // 视频封面地址
 	FavoriteCount uint64 `json:"favorite_count"`
 	CommentCount  uint64 `json:"comment_count"`
+}
+
+func GetVideoByTime(unixTime int64) ([]*Video, error) {
+	var videos []*Video
+	latest := time.Unix(unixTime, 0)
+	err := DB.Limit(30).Where("created_at > ?", latest).Find(&videos).Error
+	if err != nil {
+		return nil, err
+	}
+	return videos, nil
 }

--- a/model/video.go
+++ b/model/video.go
@@ -15,7 +15,7 @@ type Video struct {
 func GetVideoByTime(unixTime int64) ([]*Video, error) {
 	var videos []*Video
 	latest := time.Unix(unixTime, 0)
-	err := DB.Limit(30).Where("created_at > ?", latest).Find(&videos).Error
+	err := DB.Limit(30).Where("created_at < ?", latest).Find(&videos).Error
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/serializer/feed.go
+++ b/pkg/serializer/feed.go
@@ -33,7 +33,8 @@ func BuildFeedResponse(code int, feedList []*FeedResponseBuilder, nextTime int64
 	res.Response = NewResponse(CodeSuccess, "")
 	res.NextTime = uint64(nextTime)
 	for _, feed := range feedList {
-		authorResponse
-		res.VideoList = append(res.VideoList, BuildVideoResponse())
+		authorResponse := BuildUserResponse(feed.Author, false)
+		res.VideoList = append(res.VideoList, BuildVideoResponse(feed.Video, authorResponse, false))
 	}
+	return res
 }

--- a/pkg/serializer/feed.go
+++ b/pkg/serializer/feed.go
@@ -1,8 +1,39 @@
 package serializer
 
-// Feed 视频流响应
-type Feed struct {
+import "github.com/YouthCampProj/douyin/model"
+
+const (
+	CodeNoMoreFeed = iota + 2000
+	CodeFailedGetFeed
+)
+
+var CodeFeedMessages = map[int]string{
+	CodeNoMoreFeed:    "feed is empty",
+	CodeFailedGetFeed: "failed to get feed",
+}
+
+// FeedResponse 视频流响应
+type FeedResponse struct {
 	Response
-	NextTime  uint64  `json:"next_time,omitempty"`  // 本次返回的视频中，发布最早的时间，作为下次请求时的latest_time
-	VideoList []Video `json:"video_list,omitempty"` // 视频列表
+	NextTime  uint64   `json:"next_time,omitempty"`  // 本次返回的视频中，发布最早的时间，作为下次请求时的latest_time
+	VideoList []*Video `json:"video_list,omitempty"` // 视频列表
+}
+
+type FeedResponseBuilder struct {
+	Video  *model.Video
+	Author *model.User
+}
+
+func BuildFeedResponse(code int, feedList []*FeedResponseBuilder, nextTime int64) *FeedResponse {
+	res := &FeedResponse{}
+	if code != CodeSuccess {
+		res.Response = NewResponse(code, CodeFeedMessages[code])
+		return res
+	}
+	res.Response = NewResponse(CodeSuccess, "")
+	res.NextTime = uint64(nextTime)
+	for _, feed := range feedList {
+		authorResponse
+		res.VideoList = append(res.VideoList, BuildVideoResponse())
+	}
 }

--- a/pkg/serializer/video.go
+++ b/pkg/serializer/video.go
@@ -1,13 +1,26 @@
 package serializer
 
+import "github.com/YouthCampProj/douyin/model"
+
 // Video 视频信息
 type Video struct {
 	ID            uint64 `json:"id"` // 视频唯一标识
-	Author        User   `json:"author"`
+	Author        *User  `json:"author"`
 	PlayURL       string `json:"play_url"`       // 视频播放地址
 	CoverURL      string `json:"cover_url"`      // 视频封面地址
 	FavoriteCount uint64 `json:"favorite_count"` // 视频的点赞总数
 	CommentCount  uint64 `json:"comment_count"`  // 视频的评论总数
 	IsFavorite    bool   `json:"is_favorite"`    // true-已点赞，false-未点赞
+}
 
+func BuildVideoResponse(video *model.Video, author *User, isFavorite bool) *Video {
+	return &Video{
+		ID:            video.ID,
+		Author:        author,
+		PlayURL:       video.PlayURL,
+		CoverURL:      video.CoverURL,
+		FavoriteCount: video.FavoriteCount,
+		CommentCount:  video.CommentCount,
+		IsFavorite:    isFavorite,
+	}
 }

--- a/service/feed.go
+++ b/service/feed.go
@@ -1,0 +1,37 @@
+package service
+
+import (
+	"github.com/YouthCampProj/douyin/model"
+	"github.com/YouthCampProj/douyin/pkg/serializer"
+	"log"
+)
+
+type FeedService struct {
+	LatestTime int64
+}
+
+func (fs *FeedService) GetFeed() *serializer.FeedResponse {
+	var feedList []*serializer.FeedResponseBuilder
+	videoList, err := model.GetVideoByTime(fs.LatestTime)
+	if err != nil {
+		log.Println(err)
+		return serializer.BuildFeedResponse(serializer.CodeFailedGetFeed, nil, 0)
+	}
+	if len(videoList) == 0 {
+		return serializer.BuildFeedResponse(serializer.CodeNoMoreFeed, nil, 0)
+	}
+	for i := range videoList {
+		author, err := model.GetUserByID(videoList[i].AuthorID)
+		if err != nil {
+			continue
+		}
+		feed := &serializer.FeedResponseBuilder{
+			Video:  videoList[i],
+			Author: author,
+		}
+		feedList = append(feedList, feed)
+
+	}
+	latestTime := videoList[len(videoList)-1].CreatedAt.Unix()
+	return serializer.BuildFeedResponse(serializer.CodeSuccess, feedList, latestTime)
+}

--- a/service/publish.go
+++ b/service/publish.go
@@ -1,0 +1,1 @@
+package service

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -34,3 +34,9 @@ func Str2uint64(str string) uint64 {
 	res, _ := strconv.ParseUint(str, 10, 64)
 	return res
 }
+
+// Str2int64 将字符串转换为int64 使用前请确保传入的字符串是合法的
+func Str2int64(str string) int64 {
+	res, _ := strconv.ParseInt(str, 10, 64)
+	return res
+}


### PR DESCRIPTION
https://github.com/YouthCampProj/douyin/blob/69d6d26eec07b0c97f75533f1763b45f04d1cf14/pkg/serializer/feed.go#L22-L25
目前是通过额外构造中间结构的方式对视频流响应体进行构造
但是不太确定未登录状态和登入状态下视频流要怎么获取点赞和关注状态
API文档中feed接口仅传入了时间戳 没有任何可供定位用户的信息
